### PR TITLE
allow flexibility to specify a branch as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ staging:
 
 2. Install gem `qops` to your system. Be sure to use gem install `qops`. Do not include it as part of the bundle of your repo as it is mean't to be run outside of the scope of your project.
 3. Run `qops list` to get a list of commands you can run.
+4. Run `qops help <command>` for more information on command argument options
 
 ## FAQ:
 

--- a/lib/qops/deployment/app.rb
+++ b/lib/qops/deployment/app.rb
@@ -2,7 +2,9 @@ class Qops::Deploy < Thor
   include Qops::DeployHelpers
 
   desc 'app', 'Deploy the latest version of the app to the environment'
+  option :branch
   def app
+    initialize_options
     if config.deploy_type == :staging
       instances = [retrieve_instance].compact
       if instances.count == 0

--- a/lib/qops/deployment/helpers.rb
+++ b/lib/qops/deployment/helpers.rb
@@ -3,6 +3,10 @@ module Qops::DeployHelpers
 
   private
 
+  def initialize_options
+    config.revision = options[:branch] if options[:branch]
+  end
+
   def config
     return @_config if @_config
 

--- a/lib/qops/deployment/instances.rb
+++ b/lib/qops/deployment/instances.rb
@@ -2,7 +2,9 @@ class Qops::Instance < Thor
   include Qops::DeployHelpers
 
   desc 'up', 'Deploy the current branch to a new or existing environment (default: staging)'
+  option :branch
   def up
+    initialize_options
     # Get the instance(s) to work with if they exist. In production we always create a new instacne
     instance = retrieve_instance if config.deploy_type == :staging
 
@@ -82,11 +84,13 @@ class Qops::Instance < Thor
     end
 
     # Deploy the latest code to instance
-    Qops::Deploy.new.app
+    Qops::Deploy.new([], options).app
   end
 
   desc 'down', 'Remove the instance associated with this branch or one given (default: staging, current branch)'
+  option :branch
   def down
+    initialize_options
     # Get the instance to shutdown
     if config.deploy_type == :staging
       instance = retrieve_instance

--- a/lib/qops/environment.rb
+++ b/lib/qops/environment.rb
@@ -3,7 +3,7 @@ require 'quandl/config'
 class Qops::Environment
   include Quandl::Configurable
 
-  attr_reader :revision
+  attr_accessor :revision
 
   def self.file_name
     'opsworks'

--- a/lib/qops/version.rb
+++ b/lib/qops/version.rb
@@ -1,3 +1,3 @@
 module Qops
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
Tracker Ticket: https://quandl.atlassian.net/browse/AP-105
## Description:
- allow `qops qops:instance:up --branch=my_branch` (same support for `qops qops:instance:down` and `qops qops:deploy:app`) so that teamcity can run commands without needing to checkout github branch
- update readme
## Note to the reviewer:
## Is there a migration?

NO
## Note to QA:
## Dependency(if any):
