### PR TITLE
Improvement ap 100/pass environment as variable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,8 @@ SignalException:
   Enabled: false
 ClassLength:
   Max: 200
+Metrics/ModuleLength:
+  Max: 150
 EachWithObject:
   Enabled: false
 PerceivedComplexity:

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,11 @@
+# 0.7.0
+
+* Refactored options to use thor class options for environment and branches
+* Refactored pre-task run step to fail more gracefully
+* Fix issue with help not displaying by using un-released thor version
+* Fix issue with migration being run on all servers for production deployments
+* Handle case where git does not exist on users system 
+
+# <= 0.6.3
+
+* Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,31 @@
 PATH
   remote: .
   specs:
-    qops (0.6.1)
+    qops (0.7.0)
       activesupport (>= 4.2.1)
       aws-sdk (>= 2.0.41)
-      quandl-config
+      quandl-config (>= 0.0.4)
       quandl-slack
-      thor (>= 0.19.1)
+      thor (>= 0.19.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.1)
+    activesupport (4.2.3)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
-    aws-sdk (2.0.47)
-      aws-sdk-resources (= 2.0.47)
-    aws-sdk-core (2.0.47)
-      builder (~> 3.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
+    aws-sdk (2.1.7)
+      aws-sdk-resources (= 2.1.7)
+    aws-sdk-core (2.1.7)
       jmespath (~> 1.0)
-      multi_json (~> 1.0)
-    aws-sdk-resources (2.0.47)
-      aws-sdk-core (= 2.0.47)
-    builder (3.2.2)
+    aws-sdk-resources (2.1.7)
+      aws-sdk-core (= 2.1.7)
     byebug (5.0.0)
       columnize (= 0.9.0)
     columnize (0.9.0)
@@ -37,19 +34,19 @@ GEM
       multi_json (~> 1.0)
     json (1.8.3)
     minitest (5.7.0)
-    multi_json (1.11.0)
-    parser (2.2.2.5)
+    multi_json (1.11.2)
+    parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
-    quandl-config (0.0.3)
+    quandl-config (0.0.4)
       activesupport
     quandl-slack (0.0.2)
       quandl-config
       slack-notifier (>= 1.0)
     rainbow (2.0.0)
-    rubocop (0.31.0)
+    rubocop (0.32.1)
       astrolabe (~> 1.3)
-      parser (>= 2.2.2.1, < 3.0)
+      parser (>= 2.2.2.5, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
@@ -57,7 +54,7 @@ GEM
       rubocop (>= 0.30.1)
     ruby-progressbar (1.7.5)
     slack-notifier (1.2.1)
-    thor (0.19.1)
+    thor (0.19.1.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -69,3 +66,6 @@ DEPENDENCIES
   byebug
   qops!
   rubocopter (>= 0.1.6)
+
+BUNDLED WITH
+   1.10.5

--- a/lib/qops.rb
+++ b/lib/qops.rb
@@ -1,14 +1,14 @@
 require 'thor'
+require 'thor/group'
 require 'aws-sdk'
 require 'json'
 require 'fileutils'
 require 'active_support/all'
 require 'pp'
+require 'optparse'
+require 'erb'
 
 require 'quandl/slack'
-
-module Qops
-end
 
 require_relative 'qops/environment'
 require_relative 'qops/helpers'
@@ -17,27 +17,15 @@ require_relative 'qops/deployment/app'
 require_relative 'qops/deployment/instances'
 require_relative 'qops/cookbook/cookbook'
 
-# The following should get refactored and merged into quandl-config project.
-if ARGV[0] && ARGV[0].start_with?('qops')
-  project_root = Pathname.new(Quandl::ProjectRoot.root)
-  file_path = project_root.join('config', "#{Qops::Environment.file_name}.yml")
-
-  if File.exist?(file_path)
-    raw_config = File.read(file_path)
-    erb_config = ERB.new(raw_config).result
-    configs = YAML.load(erb_config)
-    ENV['QUANDL_ENV'] ||= Thor::Shell::Color.new.ask("\nRun command using config:", :yellow, limited_to: configs.keys.reject { |g| g.start_with?('_') }, echo: false)
-    puts "\nRunning commands with config #{ENV['QUANDL_ENV']}"
-  end
-end
-
-require 'erb'
+# Migrate this into quandl config project
 module Quandl
-  class Config
+  class Config < ::OpenStruct
+    cattr_accessor :environment
+
     private
 
     def project_environment
-      ENV['QUANDL_ENV']
+      @_environment ||= @@environment || (defined?(Rails) ? ::Rails.env : nil) || ENV['RAILS_ENV'] || ENV['RAKE_ENV'] || ENV['QUANDL_ENV'] || 'default'
     end
   end
 end

--- a/lib/qops/deployment/helpers.rb
+++ b/lib/qops/deployment/helpers.rb
@@ -1,9 +1,16 @@
 module Qops::DeployHelpers
+  extend ActiveSupport::Concern
+
   include Qops::Helpers
+
+  included do
+    class_option :branch, type: :string, default: default_branch, aliases: '-b', desc: 'The branch to use when deploying to staging type environments'
+  end
 
   private
 
-  def initialize_options
+  def initialize_run
+    super
     config.revision = options[:branch] if options[:branch]
   end
 

--- a/lib/qops/deployment/instances.rb
+++ b/lib/qops/deployment/instances.rb
@@ -1,10 +1,10 @@
 class Qops::Instance < Thor
   include Qops::DeployHelpers
 
-  desc 'up', 'Deploy the current branch to a new or existing environment (default: staging)'
-  option :branch
+  desc 'up', 'Deploy the current branch to new or existing instance(s)'
   def up
-    initialize_options
+    initialize_run
+
     # Get the instance(s) to work with if they exist. In production we always create a new instacne
     instance = retrieve_instance if config.deploy_type == :staging
 
@@ -87,10 +87,10 @@ class Qops::Instance < Thor
     Qops::Deploy.new([], options).app
   end
 
-  desc 'down', 'Remove the instance associated with this branch or one given (default: staging, current branch)'
-  option :branch
+  desc 'down', 'Remove the instance associated with the given branch'
   def down
-    initialize_options
+    initialize_run
+
     # Get the instance to shutdown
     if config.deploy_type == :staging
       instance = retrieve_instance

--- a/lib/qops/environment.rb
+++ b/lib/qops/environment.rb
@@ -1,54 +1,54 @@
 require 'quandl/config'
 
-class Qops::Environment
-  include Quandl::Configurable
+module Qops
+  class Environment
+    include Quandl::Configurable
 
-  attr_accessor :revision
+    attr_accessor :revision
 
-  def self.file_name
-    'opsworks'
-  end
-
-  def self.notifiers
-    @_notifiers ||= Quandl::Slack.autogenerate_notifiers
-  end
-
-  def initialize
-    puts "Reading 'config/#{file_name}.yml'"
-
-    ['deploy-type', 'region', 'stack_id'].each do |v|
-      fail "Please configure #{v} before continuing." unless v
+    def self.file_name
+      'opsworks'
     end
 
-    begin
-      opsworks.config.credentials.access_key_id
-      opsworks.config.credentials.secret_access_key
-    rescue => e
-      raise "There may be a problem with your aws credentials with: aws configure: #{e}"
+    def self.notifiers
+      @_notifiers ||= Quandl::Slack.autogenerate_notifiers
     end
 
-    puts "Running commands in deploy environment: #{deploy_type}"
+    def initialize
+      puts "Reading 'config/#{file_name}.yml'"
 
-    @revision = (deploy_type == :staging ? `git symbolic-ref --short HEAD`.strip : 'master')
-  end
+      ['deploy-type', 'region', 'stack_id'].each do |v|
+        fail "Please configure #{v} before continuing." unless v
+      end
 
-  def file_name
-    self.class.file_name
-  end
+      begin
+        opsworks.config.credentials.access_key_id
+        opsworks.config.credentials.secret_access_key
+      rescue => e
+        raise "There may be a problem with your aws credentials with: aws configure: #{e}"
+      end
 
-  def opsworks
-    @_opsworks ||= Aws::OpsWorks::Client.new(region: configuration.region)
-  end
+      puts "Running commands in deploy environment: #{deploy_type}"
+    end
 
-  def cookbook_json
-    configuration.cookbook_json || 'custom.json'
-  end
+    def file_name
+      self.class.file_name
+    end
 
-  def method_missing(method_sym, *arguments, &block)
-    if configuration.respond_to?(method_sym)
-      configuration.send(method_sym, *arguments, &block)
-    else
-      super
+    def opsworks
+      @_opsworks ||= Aws::OpsWorks::Client.new(region: configuration.region)
+    end
+
+    def cookbook_json
+      configuration.cookbook_json || 'custom.json'
+    end
+
+    def method_missing(method_sym, *arguments, &block)
+      if configuration.respond_to?(method_sym)
+        configuration.send(method_sym, *arguments, &block)
+      else
+        super
+      end
     end
   end
 end

--- a/lib/qops/version.rb
+++ b/lib/qops/version.rb
@@ -1,3 +1,3 @@
 module Qops
-  VERSION = '0.6.2'
+  VERSION = '0.7.0'
 end

--- a/qops.gemspec
+++ b/qops.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'thor', '>= 0.19.1'
+  s.add_runtime_dependency 'thor', '>= 0.19.1.1'
   s.add_runtime_dependency 'aws-sdk', '>= 2.0.41'
-  s.add_runtime_dependency 'quandl-config'
+  s.add_runtime_dependency 'quandl-config', '>= 0.0.4'
   s.add_runtime_dependency 'quandl-slack'
   s.add_runtime_dependency 'activesupport', '>= 4.2.1'
 end


### PR DESCRIPTION
Tracker Ticket: https://quandl.atlassian.net/browse/AP-100
## Description
- Allow for passing an environment option to qops to bypass the environment query when running
## Note to the reviewer
- Refactored options to use thor class options for environment and branches
- Refactored pre-task run step to fail more gracefully
- Fix issue with help not displaying by using un-released thor version
- Fix issue with migration being run on all servers for production deployments
- Handle case where git does not exist on users system 
## Is there a migration?
- No
## Note to QA
- Read the`qops help` for a task to see options.
## Dependency
- Updated thor or use the custom built one on quandl gemfury.
