### PR TITLE
Clean staging instances

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+# 0.9.0
+
+* Added the clean command to be used to clean old staging instances that have not had commands run against them for a given period.
+
 # 0.7.0
 
 * Refactored options to use thor class options for environment and branches

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    qops (0.8.0)
+    qops (0.9.0)
       activesupport (>= 4.2.1)
       aws-sdk (>= 2.0.41)
-      quandl-config (>= 0.0.4)
+      quandl-config (>= 0.1.0)
       quandl-slack
       rainbow (~> 2.0.0)
       thor (>= 0.19.1.1)
@@ -13,7 +13,7 @@ GEM
   remote: https://rubygems.org/
   remote: https://9UhxvtZywbftWRD25bpz@gem.fury.io/quandl/
   specs:
-    activesupport (4.2.3)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -22,15 +22,13 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    aws-sdk (2.1.13)
-      aws-sdk-resources (= 2.1.13)
-    aws-sdk-core (2.1.13)
+    aws-sdk (2.1.15)
+      aws-sdk-resources (= 2.1.15)
+    aws-sdk-core (2.1.15)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.13)
-      aws-sdk-core (= 2.1.13)
-    byebug (5.0.0)
-      columnize (= 0.9.0)
-    columnize (0.9.0)
+    aws-sdk-resources (2.1.15)
+      aws-sdk-core (= 2.1.15)
+    byebug (6.0.2)
     i18n (0.7.0)
     jmespath (1.0.2)
       multi_json (~> 1.0)
@@ -40,7 +38,7 @@ GEM
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
-    quandl-config (0.0.4)
+    quandl-config (0.1.0)
       activesupport
     quandl-slack (0.0.2)
       quandl-config

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ _default: &default
   region: us-east-1
   app_name: 'wikiposit'
   instance_type: 't2.small'
+  max_instance_duration: 86400 # Optional
+  clean_commands_to_ignore: ['configure', 'shutdown] # Optional: A list of opsworks commands to ignore when calculating that last run time for the clean command. Ignores `configure` and `shutdown` commands by default.  
   cookbook_dir: cookbooks
   cookbook_name: wikiposit
   cookbook_version: "<%= IO.read(File.join(Dir.pwd, 'cookbooks/VERSION')).strip %>"

--- a/lib/qops/deployment/helpers.rb
+++ b/lib/qops/deployment/helpers.rb
@@ -46,16 +46,22 @@ module Qops::DeployHelpers
     @_custom_json
   end
 
-  def retrieve_instances
+  def retrieve_instances(options = {})
     # Describe and create instances as necessary
-    instances_results = config.opsworks.describe_instances(layer_id: config.layer_id)
+    instances_results = config.opsworks.describe_instances({ layer_id: config.layer_id }.merge(options))
 
     # Determine if instance exists.
     instances_results.data.instances
   end
 
-  def retrieve_instance
-    # Describe and create instances as necessary
+  def retrieve_instance(instance_id = nil)
+    # Retrieve a specific instance as necessary
+    if instance_id
+      instances_results = config.opsworks.describe_instances(instance_ids: [instance_id])
+      return instances_results.data.instances.first
+    end
+
+    # Get instance based on hostname
     instances_results = config.opsworks.describe_instances(layer_id: config.layer_id)
 
     # Determine if instance exists.

--- a/lib/qops/version.rb
+++ b/lib/qops/version.rb
@@ -1,3 +1,3 @@
 module Qops
-  VERSION = '0.8.1'
+  VERSION = '0.9.0'
 end

--- a/qops.gemspec
+++ b/qops.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'thor', '>= 0.19.1.1'
   s.add_runtime_dependency 'aws-sdk', '>= 2.0.41'
-  s.add_runtime_dependency 'quandl-config', '>= 0.0.4'
+  s.add_runtime_dependency 'quandl-config', '>= 0.1.0'
   s.add_runtime_dependency 'quandl-slack'
   s.add_runtime_dependency 'activesupport', '>= 4.2.1'
   s.add_runtime_dependency 'rainbow', '~> 2.0.0'


### PR DESCRIPTION
Tracker Ticket: 
- https://quandl.atlassian.net/browse/AP-419
## Description
- Adds a new clean command which will clean instances in an opsworks layer based on configuration options.
- Clean happen if the last command run on an instance was greater than `specified time ago` (1 day default)
## Note to the reviewer
- Minor refactor the the instance:down command to leverage in the clean command.
## Is there a migration?
- No
## Note to QA
- Will need to implement a config file per staging environment we wish to activate this on.
- Possibly run from teamcity
## Dependency
- None
## Screenshot
- None
