### PR TITLE
Fix ap 2998/qops return code error

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,6 @@
+# 1.4.9
+* fix issue where status 0 is return on certain errors
+
 # 1.4.8
 * fixed empty online instances check
 

--- a/lib/qops/deployment/app.rb
+++ b/lib/qops/deployment/app.rb
@@ -89,6 +89,12 @@ class Qops::Deploy < Thor
     )
   end
 
+  # Allow thor to exit on any failure
+  # and return status code 1
+  def self.exit_on_failure?
+    true
+  end
+
   private
 
   def custom_json

--- a/lib/qops/version.rb
+++ b/lib/qops/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Qops
-  VERSION = '1.4.8'.freeze
+  VERSION = '1.4.9'.freeze
 end


### PR DESCRIPTION
https://quandl.atlassian.net/browse/AP-2998

allow qops to set status codes 1 when command exits with errors.