### PR TITLE
CP-4945: Added the ability to include overridden templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 
 ## FAQ:
 
+### Q: Can I Override Built-In Templates
+
+You can create a overridden_built_in_templates folder within you cookbooks folder.
+/cookbooks/overridden_built_in_templates/unicorn/templates/default/unicorn.conf.erb
+
 ### Q: The `qops` gem is currently not public. How do I access it?
 
 Please add your personal gemfury source to the gem path to install it.

--- a/lib/qops/cookbook/cookbook.rb
+++ b/lib/qops/cookbook/cookbook.rb
@@ -15,6 +15,7 @@ class Qops::Cookbook < Thor
   desc 'package', 'Package the cookbooks into a zip file in vendor'
   def package
     initialize_run
+    move_custom_templates
     Dir.chdir(config.cookbook_dir) do
       remove_zip_files
       system("zip -r #{artifact_name} vendor/*")
@@ -156,6 +157,17 @@ class Qops::Cookbook < Thor
 
   def vendor_dir
     File.join(config.cookbook_dir, 'vendor')
+  end
+
+  def move_custom_templates
+    Dir.chdir(config.cookbook_dir) do
+      custom_template_directory = File.join('vendor', config.cookbook_name, 'overridden_built_in_templates')
+      if File.directory?(custom_template_directory)
+        say('Moving Custom Templates:', :green)
+        system("mv #{custom_template_directory}/* vendor")
+        system("rm -rf #{custom_template_directory}")
+      end
+    end
   end
 
   def remove_zip_files

--- a/lib/qops/version.rb
+++ b/lib/qops/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Qops
-  VERSION = '1.7.0'
+  VERSION = '1.7.1'
 end


### PR DESCRIPTION
If the folder exists, it will move all overridden templates to the root directory before zipping the file.

https://quandl.atlassian.net/browse/CP-4945