### PR TITLE
version bump 1.8.0

### DIFF
--- a/lib/qops/version.rb
+++ b/lib/qops/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Qops
-  VERSION = '1.7.3'
+  VERSION = '1.8.0'
 end

--- a/qops.gemspec
+++ b/qops.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'activesupport', '>= 4.2.1'
+  s.add_runtime_dependency 'activesupport', '>= 4.2.1', '< 6.0'
   s.add_runtime_dependency 'aws-sdk', '~> 3.0'
   s.add_runtime_dependency 'quandl-config', '>= 0.1.0'
   s.add_runtime_dependency 'quandl-slack'


### PR DESCRIPTION
limit gemspec's activesupport to be lower than  6.0.  Helps fix an issue in Quandl Jenkins where deployments fail due to open-ended dependency bounds.