### PR TITLE
Relax ruby version min bound.

### DIFF
--- a/lib/qops/version.rb
+++ b/lib/qops/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Qops
-  VERSION = '1.8.1'
+  VERSION = '1.8.2'
 end

--- a/qops.gemspec
+++ b/qops.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.1'
 
   s.files = Dir['{lib,bin}/**/*', 'README.md']
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Jeffbox/databox relies on ruby 2.1, and hacking around global qops is cumbersome. Verified qops is indeed working with 2.1 in jeffbox repo.